### PR TITLE
Add project-level 3P documents (PITCH/PLEDGE/PLAN)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Module descriptions — The 3P Protocol (3P)
 
-Each unit of code (class, module, subsystem, or system) carries up to three named prose layers — the **3P** — in its XML-doc `<remarks>`, using custom elements `<pitch>`, `<pledge>`, `<plan>`. Generic definition: `docs/MODULE_DESCRIPTIONS.md`; C# placement convention and examples: `docs/MODULE_DESCRIPTIONS.AmbientServices.md`. Refer to these by their exact names — Pitch, Pledge, Plan — never informal synonyms.
+Each unit of code (class, module, subsystem, or system) carries up to three named prose layers — the **3P** — in its XML-doc `<remarks>`, using custom elements `<pitch>`, `<pledge>`, `<plan>`. The library viewed as one whole-system unit carries its layers in dedicated project-level files instead: `docs/PITCH.md`, `docs/PLEDGE.md`, `docs/PLAN.md`, linked from `README.md`. Generic definition: `docs/MODULE_DESCRIPTIONS.md`; C# placement convention and examples: `docs/MODULE_DESCRIPTIONS.AmbientServices.md`. Refer to these by their exact names — Pitch, Pledge, Plan — never informal synonyms.
 
 ### The 3P Protocol (3P)
 - **Pitch** *(Value Proposition)* — short; the caller's "is this what I need?" decision. Problem/benefit, optional limits.

--- a/README.md
+++ b/README.md
@@ -5,6 +5,16 @@
 
 AmbientServices is a .NET library that provides abstractions for services which are both ubiquitous and optional, allowing assemblies that use it to be used in a variety of systems that provide vastly different implementations (or no implementation) of those services.
 
+## How this library is documented — The 3P Protocol
+
+This project describes each unit of code — from a single class up to the whole library — with up to three short prose layers, the **3P**: a **Pitch** (why you'd use it), a **Pledge** (what it promises and how you interact with it), and a **Plan** (how it's built). Per-type layers live in the XML-doc `<remarks>` of each type; the layers for the library as a whole live in their own documents:
+
+- [**Pitch**](docs/PITCH.md) — is this library what you need?
+- [**Pledge**](docs/PLEDGE.md) — the behavioral contract shared by every ambient service.
+- [**Plan**](docs/PLAN.md) — how the ambient-service mechanism is built and the trade-offs it strikes.
+
+The methodology itself is defined in [docs/MODULE_DESCRIPTIONS.md](docs/MODULE_DESCRIPTIONS.md) (with a C#-specific companion, [docs/MODULE_DESCRIPTIONS.AmbientServices.md](docs/MODULE_DESCRIPTIONS.AmbientServices.md)) and draws on a shared [glossary](docs/GLOSSARY.md).
+
 ## Basic Services
 The basic ambient services include local caching, an atomic cache, clock, logging, progress/cancellation, and settings.  Interfaces for those services are provided here.
 By accessing these services through the interfaces provided here, library authors can utilize new basic services as they become available without changing their external interface, and library consumers can use those libraries without having to provide dependencies for systems that they may or may not use.

--- a/docs/MODULE_DESCRIPTIONS.AmbientServices.md
+++ b/docs/MODULE_DESCRIPTIONS.AmbientServices.md
@@ -18,6 +18,10 @@ All three live in the type's XML-doc `<remarks>`, using **custom elements** name
 - An **abstraction** (interface) carries `<pitch>` and a `<pledge>` whose body is the behavioral-protocol prose.
 - A **concrete realization** carries `<pitch>`, one or more `<pledge>` elements, and `<plan>`. A `<pledge>` containing a `<see cref>` to an abstraction means "this unit fulfills that abstraction's Pledge; its terms apply here." Additional `<pledge>` elements state realization-specific extensions; omit them when the realization adds nothing.
 
+## Where the whole-library layers live
+
+The library viewed as one unit is documented, one layer per file, in the `docs` folder — [`docs/PITCH.md`](PITCH.md), [`docs/PLEDGE.md`](PLEDGE.md), and [`docs/PLAN.md`](PLAN.md) — kept beside the other 3P meta-documents (`MODULE_DESCRIPTIONS.md`, `GLOSSARY.md`, `DRIFT.md`). The `README.md` carries a short explanation of the 3P and links to all three so the repository's entry point navigates straight to them (and so public-repo indexers pick them up). These are written for the whole-system unit's purpose — adoption triage, the cross-cutting contract, and the system-level architecture — not as a digest of the per-type layers, and each begins with a one-line note identifying which layer it is and linking back to this methodology. A significant change to the library-wide Pitch, Pledge, or Plan updates the matching file in the same change, agreed in prose first, exactly as for per-type layers.
+
 ## Examples
 
 - **Different Pitches, similar shape.** `IAmbientLocalCache` and `IAmbientSharedCache` share the same "store an item under a string key with optional expiration" shape (`Retrieve`/`Store`/`Remove`/`Clear`), but sell different things. `IAmbientLocalCache` pitches an in-process cache that can safely hold objects with references and `IDisposable` items (with hand-off-on-retrieve semantics); `IAmbientSharedCache` pitches a cache for serializable objects that may live in another process or machine. Same shape, different Pitches — and different Pledges, since only the local one promises to handle non-serializable and disposable values.

--- a/docs/MODULE_DESCRIPTIONS.md
+++ b/docs/MODULE_DESCRIPTIONS.md
@@ -70,6 +70,8 @@ Use this as an on-demand check, not a stored description: hand the layers (plus 
 
 Each project defines a placement convention appropriate to its language and documentation system, recorded in that project's companion module-descriptions file. Whatever the mechanism, an **abstraction** carries a Pitch and a Pledge; a **concrete realization** carries a Pitch, one or more Pledges, and a Plan — a realization's Pledge is usually a reference to the abstraction's Pledge, plus any realization-specific extensions.
 
+The highest-altitude unit — the **whole system** (a library, service, or application viewed as one thing) — usually has no single place in the source to attach to, since it is realized by many types rather than one. For that unit the layers are best kept as dedicated project-level documents (one per layer), placed where they are easy to discover and index — and linked from the project's entry point (e.g., the README) so a reader arriving at the repository can navigate straight to them. The project companion records the exact filenames and location.
+
 ## Glossary
 
 A project that adopts this model keeps a single cross-cutting **glossary** of its invented vocabulary — the names of its core abstractions, data structures, and techniques. The glossary is orthogonal to the three per-unit layers: those describe one unit each, while the glossary defines the terms every unit's prose relies on. Its value is disproportionate and its upkeep is nearly free — defining a term once lets every Pitch, Pledge, and Plan reference it tersely instead of re-explaining it, and it gives every collaborator, human or AI, one authoritative meaning per term. Add an entry when a term is coined; entries change far more slowly than code.

--- a/docs/PITCH.md
+++ b/docs/PITCH.md
@@ -1,0 +1,35 @@
+# AmbientServices — Pitch
+
+*This is the whole-library **Pitch** layer of the 3P Protocol — the "is this what I need?" triage layer for the project as a single unit. See [MODULE_DESCRIPTIONS.md](MODULE_DESCRIPTIONS.md) for what the 3P are, [PLEDGE.md](PLEDGE.md) for what the library promises, and [PLAN.md](PLAN.md) for how it is built.*
+
+## The problem
+
+Almost every non-trivial program leans on a handful of services that are simultaneously **ubiquitous** and **optional**: caching, logging, settings, progress/cancellation, performance monitoring, backend status checks, and maybe an artificially-controllable clock. They are needed almost everywhere, yet any single program may want a rich implementation, a trivial one, or none at all, sometimes using different ones in different contexts in the same program, especially when running tests.
+
+Dependency injection is the usual answer, but it charges a high price for services that are optional anyway. The consumer has to thread each dependency through every constructor — or worse, every function — and when a library it uses *adds or removes* one of these dependencies, every one of those construction sites has to change, and if the location of that call is deep within the system, this can result in a lot of changes, and middle-layer code that inexplicably takes parameters for these services needed by lower layers, whose implementation should be completely hidden from those layers. For services that are required, that cost may be justified. For services that are environmental and optional, it is mostly friction.
+
+## What this library gives you
+
+AmbientServices lets library authors program against small **ambient** interfaces and lets consumers supply implementations — or not — with a single registration that every participating library automatically picks up. A library gains the benefit of a new ambient service without changing its public surface, and a consumer adopts (or ignores) that service without editing a single call site.  It's like adding features to the language instead of tracking and building it all yourself
+
+You would reach for AmbientServices when you want:
+
+- To use cross-cutting services (cache, clock, logging, settings, progress) without plumbing them through every layer of your system.
+- To ship a library whose optional dependencies can be upgraded by the consumer, later, from the outside.
+- Always-on, low-overhead performance and saturation monitoring that does not require a profiler run.
+- Automated backend status checking with concise, farm-wide rollups.
+
+## What it deliberately is not
+
+- **Not a replacement for DI of *required* services.** Ambient resolution is for things whose absence is acceptable and whose presence is environmental; genuinely required collaborators still belong in constructors.
+- **Not a channel for values that change outputs in ways the caller cares about.** By design, an ambient service must behave environmentally — see [PLEDGE.md](PLEDGE.md). Caching may return bounded-stale results, a clock may simulate time, settings act as inputs, but nothing may alter a function's input→output relationship *unexpectedly*.
+- **Not a heavyweight framework.** It carries no external dependencies and stays out of your object graph until you ask for a service.
+
+## What's inside (so you can decide)
+
+- **Basic services** — local cache, atomic (single-flight) cache, clock, logger, progress/cancellation, and settings.
+- **Performance services** — statistics, an always-on coarse-grained service profiler, and a bottleneck/saturation detector for estimating scalability before load testing.
+- **Status** — background backend dependency testing with heterogeneous/homogeneous aggregation and SMS-and-detail rollups across server farms.
+- **Utilities** — notably `DisposeResponsibility<T>` for making dispose ownership visible and leak-detectable, plus assorted threading, string, and formatting helpers.
+
+If the per-service trade-offs are what you're weighing, each interface and each implementation carries its own Pitch in its XML-doc `<remarks>`; this file is only the library-wide decision.

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -1,0 +1,40 @@
+# AmbientServices — Plan
+
+*This is the whole-library **Plan** layer of the 3P Protocol — how the ambient-service mechanism is built at the system altitude, the building blocks it rests on, and the cross-cutting trade-offs every realization inherits. See [MODULE_DESCRIPTIONS.md](MODULE_DESCRIPTIONS.md) for what the 3P are, [PITCH.md](PITCH.md) for the adoption decision, and [PLEDGE.md](PLEDGE.md) for the contract this implements. This file is deliberately not a digest of the per-service Plans — each concrete implementation carries its own Plan in its XML-doc `<remarks>`; this one covers only what is common to the whole library and how the ambient machinery itself works.*
+
+## The resolution machine
+
+The heart of the library is `AmbientService<T>`, a small accessor that holds a service's **Global** value and exposes the **Local** (effective) value and the call-context **Override**. The override is stored in an `AsyncLocal<T>`, so it flows with the async execution context and is naturally scoped to a logical call flow rather than a thread. `Local` resolves to the override when one is present and the global otherwise. Scoped-override helpers (e.g. `ScopedLocalServiceOverride<T>` / `ScopedLocalOverride`) capture the prior value, install a new one, and restore it on `Dispose`, which is what makes overrides nest and unwind in stack order.
+
+This `AsyncLocal`-based design is also the direct cause of the assembly-load-context behavior in the [Pledge](PLEDGE.md): the accessor's statics live in whichever copy of the AmbientServices assembly a load context resolved, so state is shared across contexts exactly when the assembly is shared, and not otherwise.
+
+## Automatic discovery
+
+Global defaults are supplied by types marked `[DefaultAmbientService]`, found by scanning loaded assemblies; a default is constructed lazily and used until something replaces the global. The Status subsystem performs its own reflection pass, discovering `StatusChecker`/`StatusAuditor` subclasses with public parameterless constructors and registering them, then activating them only when the status system is started. Both mechanisms trade a small, one-time reflection cost for the "works with zero registration" property the Pitch promises.
+
+## Foundational building blocks
+
+- **`AmbientClock`** underlies all timing in the library — timeouts, rotation, stopwatches, timers. Routing time through it (rather than `DateTime.UtcNow` / `Stopwatch` / `System.Timers.Timer` directly) is what lets tests pause and skip time deterministically, and it is the reason the coding standard mandates `AmbientClock.UtcNow`.
+- **`AsyncLocal<T>`** carries call-context overrides and other context-following state (progress, call stack) so it aligns with `async`/`await` flow instead of threads.
+- **Lock-free / interlocked concurrency** is the default throughout — statistics, profiler, bottleneck detector, and caches use atomic operations and optimistic update loops rather than mutual exclusion.
+
+## Cross-cutting engineering constraints
+
+These constraints are not incidental style; they shape every realization in the library and any functionally-equivalent reimplementation should honor them:
+
+- **Async all the way.** `ValueTask` is preferred over `Task`; async-avoidance patterns (`.Result`, `GetAwaiter().GetResult()`, sync-over-async) are never used — async is propagated up the call stack instead. `ConfigureAwait` is not used anywhere.
+- **No `lock` keyword** (and no async-unfriendly lock types). Concurrency is handled with lock-free algorithms where possible, and async-friendly waits where a wait is genuinely required, so the code never has to be un-blocked later for asyncification.
+- **Optionality and nullability** are pervasive by design — every service can be absent, so the code and its helpers treat a missing service as a no-op rather than an error.
+- **Backwards-compatible evolution.** Public input schemas may only gain optional/nullable additions and output schemas may not drop non-deprecated members, so consumers can upgrade the single package without breakage.
+- **Warning-free and dependency-free.** The library introduces no external assembly dependencies and is kept warning-free, keeping it safe to drop into any host.
+
+## Targeting and packaging
+
+The library targets **.NET Standard 2.0** plus **.NET 8.0–10.0**, shipped as a single NuGet package (`AmbientServices`); the test suite runs on .NET 10.0. Broad target coverage keeps it usable from legacy hosts up through current runtimes without the consumer choosing a variant.
+
+## System-wide trade-offs
+
+- **Always-on, coarse-grained monitoring over precision.** The profiler and bottleneck detector are built to run continuously at negligible overhead (lock-free accumulation, per-context surveyors, rotating time windows) rather than to give profiler-grade precision. The cost is that saturation and top-N figures are approximations the consumer must interpret conservatively.
+- **Optionality over guaranteed presence.** Making every service suppressible and null-tolerant removes plumbing and lets libraries adopt services non-invasively, at the cost of null-checks (mostly hidden in helpers) at each use.
+- **Context-following state over thread-locality.** `AsyncLocal` gives correct behavior under `async`/`await` and scoped overrides, at the cost of the load-context sharing subtlety documented in the Pledge.
+- **Regeneration caveat.** The Pitch and Pledge, with these building blocks, are enough to rebuild a *functionally equivalent* library, but not a *wire-* or *format-compatible* one: serialization formats, on-disk log/rotation layouts, and key encodings live below this altitude and are intentionally left to the per-service Plans.

--- a/docs/PLEDGE.md
+++ b/docs/PLEDGE.md
@@ -1,0 +1,50 @@
+# AmbientServices — Pledge
+
+*This is the whole-library **Pledge** layer of the 3P Protocol — the behavioral contract shared by the library as a single unit: the rules that hold across every ambient service and that the interface signatures cannot express by themselves. See [MODULE_DESCRIPTIONS.md](MODULE_DESCRIPTIONS.md) for what the 3P are, [PITCH.md](PITCH.md) for whether the library fits your need, and [PLAN.md](PLAN.md) for how these promises are implemented. Each interface additionally carries its own Pledge in its XML-doc `<remarks>`; the promises below apply on top of all of them.*
+
+## The ambient contract
+
+The single rule that governs everything registered as an ambient service: **it must behave environmentally.** It must not change the relationship between a consuming function's inputs and its outputs in any way the caller would be surprised by. A service may have side effects, but they must fall into one of two categories — effects the caller does not observe in the result at all, or effects the caller already understands to be variable.
+
+Concretely, per service kind:
+
+- **Logging and profiling** never affect outputs or control flow. The only permissible effect is the record itself. (Consumers must therefore keep message-generating lambdas free of side effects, since the logger may not invoke them.)
+- **Caching** may return bounded-stale results, but only for functions that already have hidden inputs (a database, a remote store). A cache key must incorporate every input that identifies the cached item; a key that omits an input makes results order-dependent, which is a usage error the caller owns.
+- **Clock** may make time appear to pass faster, slower, or not at all (for testing timeouts and heavy-load scheduling). It never runs backward. Callers must not treat wall-clock progression as guaranteed.
+- **Progress and cancellation** never affect the result except by aborting the operation entirely, in which case there is no result.
+- **Settings** are, by definition, inputs — configuration-shaped parameters the caller has chosen not to pass on the stack. They may change a function's output, but never in a way the caller is expected to be concerned about.
+- **Security context** falls back to the environment (e.g., ambient cloud credentials) rather than being threaded explicitly, because passing such credentials around is itself undesirable.
+
+A consumer relies on this contract when it uses a service without accounting for the service's presence; an implementer promises to honor it. Anything that would violate it does not belong behind an ambient interface — it belongs in an explicit dependency.
+
+## Optionality
+
+Every ambient service is optional. Any service may be absent, or may be **suppressed** (set to null) for a call context. Consumers must tolerate absence — the canonical pattern is a null-conditional call (`service?.Method(...)`) that becomes a no-op when the service is not present. Helper wrappers in this library already fold this in. Code must never assume a service exists.
+
+## Resolution and override protocol
+
+Each ambient service is reached through three related views:
+
+- **Global** — the process-wide default for the service. When nothing else is set, this is what callers get. It may be replaced (including with null to disable the service).
+- **Override** — a call-context-local replacement that flows with the async execution context and is undone when its scope is disposed. Setting an override affects only the current logical call flow, not other threads or requests.
+- **Local** — the *effective* service a caller actually gets: the call-context override if one is in force, otherwise the global. Consumers should read `Local`; overriders write `Override` (typically via a scoped, disposable helper that restores the prior value).
+
+Overrides nest and restore in stack order. This is the mechanism behind per-test service substitution, per-request isolation, and selectively suppressing a service before calling less-trusted code.
+
+## Startup, shutdown, and change
+
+The global implementation of a service is expected to be **swapped as initialization progresses** — for example, settings may begin as built-in defaults, then become a local configuration reader, then a centralized store, without any centralized startup orchestration. Because of this:
+
+- Consumers must not depend on a service's implementation being final, or on any particular ordering, at the moment they first read it.
+- Where a service exposes change notifications (settings value changes being the primary case), consumers that need to react should subscribe rather than sample. **Notifications may arrive asynchronously, on any thread, at any time**, and may arrive after the value has already changed; consumers must not assume a notification precedes an observable change.
+
+## Automatic discovery
+
+Two subsystems populate themselves by reflection rather than explicit registration, and callers rely on that:
+
+- **Default implementations** are discovered from loaded assemblies and used as the global service until overridden. A consumer gets a working default for a service without registering anything.
+- **Status checkers and auditors** with public parameterless constructors are discovered, constructed, and registered automatically, but only begin running after the status system is explicitly started. Checkers/auditors that need non-trivial construction can be registered manually. (Lazy registration is discouraged: detecting backend problems at startup is preferable to detecting them only when a backend is first touched.)
+
+## Assembly-load-context boundary
+
+Ambient state flows across an `AssemblyLoadContext` boundary **only where the AmbientServices assembly itself is shared** across those contexts. By default a load context loads its own copy of already-loaded assemblies, giving it independent global/override state — so a service set on one side is invisible on the other. Consumers that load plugins must decide, deliberately, whether to share the assembly (and thus flow ambient services) or isolate it, and must suppress individual services across the boundary when a plugin is only partially trusted. Treating context-crossing ambient state as automatically shared is a contract violation that surfaces as services mysteriously reverting to defaults.


### PR DESCRIPTION
## What

Adds whole-library **3P** layers as dedicated project-level documents, filling the gap where the highest-altitude unit (the library viewed as a single thing) previously had no home — per-type 3P live in XML-doc `<remarks>`, but the system-level unit had nowhere to attach.

- **`docs/PITCH.md`** — library-wide adoption triage: the ubiquitous-but-optional problem, what you get, explicit non-goals, and a what's-inside map.
- **`docs/PLEDGE.md`** — the cross-cutting behavioral contract: the "behave environmentally" rule with per-service side-effect profiles, optionality, Global/Override/Local resolution, startup-swap + change-notification semantics, auto-discovery, and the assembly-load-context boundary.
- **`docs/PLAN.md`** — system architecture: the `AmbientService<T>` + `AsyncLocal` resolution machine, discovery, `AmbientClock` foundation, the async/lock-free/dependency-free constraints, targeting, and system-wide trade-offs. Deliberately not a digest of the per-type Plans.

## Methodology + entry-point updates (same-change, per the 3P prose-first rule)

- **`docs/MODULE_DESCRIPTIONS.md`** — generic principle: the whole-system unit's layers live in dedicated, linked project-level documents.
- **`docs/MODULE_DESCRIPTIONS.AmbientServices.md`** — records the concrete `docs/PITCH|PLEDGE|PLAN.md` filenames/location and their purpose.
- **`CLAUDE.md`** — operative pointer to the project-level files.
- **`README.md`** — new short "The 3P Protocol" section after the intro, linking to the three files plus the methodology and glossary docs, so the repo entry point (and public-repo indexers) navigate straight to them.

## Notes for review

The three files are purpose-written for the whole-system unit (adoption / contract / architecture), not copied from the README. `docs/PLEDGE.md` now functions as the library's authoritative cross-cutting contract, so it's the one most worth a close read.
